### PR TITLE
Fix: "port" and "net" params were ignored in vpn init command.

### DIFF
--- a/cmd/ovpm/cmd_vpn.go
+++ b/cmd/ovpm/cmd_vpn.go
@@ -52,6 +52,7 @@ var vpnInitCommand = cli.Command{
 		cli.StringFlag{
 			Name:  "net, n",
 			Usage: fmt.Sprintf("VPN network to give clients IP addresses from, in the CIDR form (default: %s)", ovpm.DefaultVPNNetwork),
+			Value: ovpm.DefaultVPNNetwork,
 		},
 		cli.StringFlag{
 			Name:  "dns, d",
@@ -73,7 +74,7 @@ var vpnInitCommand = cli.Command{
 		}
 
 		// Set port number, if provided.
-		port := ovpm.DefaultVPNPort
+		port := c.String("port")
 		if !govalidator.IsNumeric(port) {
 			return errors.InvalidPort(port)
 		}
@@ -85,7 +86,7 @@ var vpnInitCommand = cli.Command{
 		}
 
 		// Set ipblock if provided.
-		netCIDR := ovpm.DefaultVPNNetwork
+		netCIDR := c.String("net")
 		if !govalidator.IsCIDR(netCIDR) {
 			return errors.NotCIDR(netCIDR)
 		}


### PR DESCRIPTION
Params "port" and "net" in "ovpm vpn init" command where ignored and always used default values.
Ex:

#ovpm v i  -s vpn.example.net -t -n **10.255.0.0/16** -d 77.88.7.8 -p **1194**
INFO[0026] vpn initialized **CIDR=10.9.0.0/24** HOSTNAME=vpn.example.com **PORT=1197** PROTO=TCP SERVER=OpenVPN


after this fix:
#ovpm v i  -s vpn.example.net -t -n **10.255.0.0/16** -d 77.88.7.8 -p **1194**
INFO[0003] vpn initialized **CIDR=10.255.0.0/16** HOSTNAME=vpn.example.net **PORT=1194** PROTO=TCP SERVER=OpenVPN